### PR TITLE
Switch string color gems to colorize

### DIFF
--- a/lib/simplecov-summary.rb
+++ b/lib/simplecov-summary.rb
@@ -1,6 +1,6 @@
 require 'simplecov-summary/version'
 require 'simplecov'
-require 'colored'
+require 'colorize'
 
 class SimpleCov::Formatter::SummaryFormatter
   def format(result)
@@ -21,9 +21,9 @@ class SimpleCov::Formatter::SummaryFormatter
         :red
       end
 
-      puts "  #{name.rjust(name_length)}: #{percentage}%".send(color)
+      puts "  #{name.rjust(name_length)}: #{percentage}%".colorize(color)
     end
 
-    print "  #{'Total'.rjust(name_length)}: #{result.covered_percent.round(2)}%"
+    puts "  #{'Total'.rjust(name_length)}: #{result.covered_percent.round(2)}%"
   end
 end

--- a/simplecov-summary.gemspec
+++ b/simplecov-summary.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'simplecov'
-  gem.add_dependency 'colored'
+  gem.add_dependency 'colorize'
 end


### PR DESCRIPTION
I had issues using the `colored` gem in jRuby, so I switched this to the `colorize` gem which seemed to work.

I also added a newline at the end of the summary, because I was running tests from the console.

I can bump versions of the gem if required.
